### PR TITLE
feature/fix-secure-oidc

### DIFF
--- a/charts/nifi/configs/bootstrap.conf
+++ b/charts/nifi/configs/bootstrap.conf
@@ -45,7 +45,9 @@ java.arg.5=-Dsun.net.http.allowRestrictedHeaders=true
 java.arg.6=-Djava.protocol.handler.pkgs=sun.net.www.protocol
 
 {{ if .Values.certManager.replaceDefaultTrustStore }}
-java.arg.7=-Djavax.net.ssl.trustStore=/opt/nifi/nifi-current/tls/truststore.jks
+java.arg.7=-Djavax.net.ssl.trustStore=/opt/nifi/nifi-current/tls/truststore.p12
+java.arg.8=-Djavax.net.ssl.trustStorePassword=changeme
+java.arg.9=-Djavax.net.ssl.trustStoreType=PKCS12
 {{/* if .Values.certManager.replaceDefaultTrustStore */}}{{ end }}
 
 # The G1GC is still considered experimental but has proven to be very advantageous in providing great


### PR DESCRIPTION
When oidc is secure, we need to:
1. add ca to truststore
2. update java's default truststore
3. provide password and type or java default truststore

fixes a bug where if oidc provider used tls, it would not start up as it could not pull oidc information from well_known endpoint.

---
name: Feature request
about: Pull request for this project
title: '[pnnl/helm-nifi] issue title'
labels: ''
assignees: ''
